### PR TITLE
[Common] `shared` 패키지가 ESM, CJS 모두 지원하도록 한다.

### DIFF
--- a/shared/.eslintrc.js
+++ b/shared/.eslintrc.js
@@ -19,5 +19,5 @@ module.exports = {
     project: './tsconfig.json'
   },
   plugins: ['@typescript-eslint'],
-  ignorePatterns: ['.eslintrc.js']
+  ignorePatterns: ['.eslintrc.js', 'dist', 'node_modules']
 };

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,8 +1,19 @@
 {
   "name": "shared",
   "version": "1.0.0",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "exports": {
+    ".": {
+      "require": {
+        "default": "./dist/cjs/index.js",
+        "types": "./dist/cjs/index.d.ts"
+      },
+      "import": {
+        "default": "./dist/esm/index.js",
+        "types": "./dist/esm/index.d.ts"
+      }
+    }
+  },
   "license": "MIT",
   "scripts": {
     "build": "rm -rf & tsc --build",

--- a/shared/package.json
+++ b/shared/package.json
@@ -16,7 +16,10 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "rm -rf & tsc --build",
+    "prebuild": "rm -rf dist",
+    "build": "yarn build:cjs & yarn build:esm",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:esm": "tsc -p tsconfig.esm.json",
     "lint": "eslint \"src/**/*.ts\" --fix"
   },
   "devDependencies": {

--- a/shared/tsconfig.cjs.json
+++ b/shared/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/cjs"
+  }
+}

--- a/shared/tsconfig.esm.json
+++ b/shared/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "dist/esm"
+  }
+}

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -2,17 +2,17 @@
   "compilerOptions": {
     "target": "es2016",
     "lib": ["ESNext"],
-    "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "removeComments": true,
+    "incremental": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
- #10 

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] ESM, CJS로 빌드할 수 있는 `tsconfig.json` 정의
- [X] `package.json`의 `exports`로 모듈 시스템에 따라 서로 다른 빌드물 제공하도록 함
- [X] ESM, CJS로 빌드할 수 있는 npm script 작성
