### PR TITLE
[Client] 회원가입 mock API를 작성하고 회원가입 페이지에 연동한다

### DIFF
--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -66,6 +66,7 @@ module.exports = {
     ],
     'react/self-closing-comp': 'error',
     'react/button-has-type': 'error',
+    '@typescript-eslint/return-await': 'off',
     '@typescript-eslint/strict-boolean-expressions': 'off',
     '@typescript-eslint/triple-slash-reference': 'off',
     '@typescript-eslint/no-empty-interface': 'off',

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -13,8 +13,9 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const Button = forwardRef<HTMLButtonElement, Props>(
-  ({ variant = 'filled', className = '', ...rest }) => (
+  ({ variant = 'filled', className = '', ...rest }, ref) => (
     <button
+      ref={ref}
       className={`text-off-black hover:bg-primary-400 min-h-[48px] min-w-[128px] rounded-md py-3 font-bold disabled:opacity-30 ${variantStyle[variant]} ${className}`}
       type="button"
       {...rest}

--- a/client/src/components/Input.tsx
+++ b/client/src/components/Input.tsx
@@ -14,7 +14,9 @@ const Input = forwardRef<HTMLInputElement, Props>(
         ref={ref}
         {...rest}
       />
-      {errorMessage && <div>{errorMessage}</div>}
+      {errorMessage && (
+        <div className="text-error-dark px-1">{errorMessage}</div>
+      )}
     </>
   ),
 );

--- a/client/src/components/LabelInput.tsx
+++ b/client/src/components/LabelInput.tsx
@@ -18,7 +18,7 @@ const LabelInput = forwardRef<HTMLInputElement, Props>(
         {label}
         {required && <Emergency className="fill-error-dark h-2 w-2" />}
       </label>
-      <Input id={id} {...rest} />
+      <Input id={id} {...rest} ref={ref} />
     </div>
   ),
 );

--- a/client/src/lib/api/auth.ts
+++ b/client/src/lib/api/auth.ts
@@ -1,0 +1,22 @@
+import { apiUrl } from '@/lib/constants';
+
+// TODO: 정의한 fetch 모듈로 바꿔야한다
+export const signUp = async (params: SignUpParams): Promise<any> =>
+  fetch(apiUrl.auth.signup(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(params),
+  }).then(async (res) => res.json());
+
+export interface User {
+  username: string;
+  nickname: string;
+}
+
+export interface SignUpParams {
+  username: User['username'];
+  password: string;
+  nickname: User['nickname'];
+}

--- a/client/src/lib/api/auth.ts
+++ b/client/src/lib/api/auth.ts
@@ -1,22 +1,13 @@
+import type { SignUpBody } from 'shared';
+
 import { apiUrl } from '@/lib/constants';
 
 // TODO: 정의한 fetch 모듈로 바꿔야한다
-export const signUp = async (params: SignUpParams): Promise<any> =>
+export const signUp = async (body: SignUpBody): Promise<any> =>
   fetch(apiUrl.auth.signup(), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(params),
+    body: JSON.stringify(body),
   }).then(async (res) => res.json());
-
-export interface User {
-  username: string;
-  nickname: string;
-}
-
-export interface SignUpParams {
-  username: User['username'];
-  password: string;
-  nickname: User['nickname'];
-}

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -1,3 +1,10 @@
+const authQueryKey = {
+  signup: () => ['signup'] as const,
+};
+
+export const queryKey = {
+  auth: authQueryKey,
+};
 
 const authApiUrl = {
   signup: () => `/api/user/auth`,

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -1,0 +1,8 @@
+
+const authApiUrl = {
+  signup: () => `/api/user/auth`,
+};
+
+export const apiUrl = {
+  auth: authApiUrl,
+};

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -7,7 +7,7 @@ export const queryKey = {
 };
 
 const authApiUrl = {
-  signup: () => `/api/user/auth`,
+  signup: () => `/api/user/auth/signup`,
 };
 
 export const apiUrl = {

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -7,7 +7,7 @@ export const queryKey = {
 };
 
 const authApiUrl = {
-  signup: () => `/api/user/auth/signup`,
+  signup: () => `/api/users/auth/signup`,
 };
 
 export const apiUrl = {

--- a/client/src/lib/hooks/mutations/auth.ts
+++ b/client/src/lib/hooks/mutations/auth.ts
@@ -1,6 +1,5 @@
-import type { SignUpParams } from '@/lib/api/auth';
 import type { UseMutationResult } from '@tanstack/react-query';
-import type { SignUpResult } from 'shared';
+import type { SignUpBody, SignUpResult } from 'shared';
 
 import { useMutation } from '@tanstack/react-query';
 
@@ -11,11 +10,11 @@ import { queryKey } from '@/lib/constants';
 export const useSignUpMutation = (): UseMutationResult<
   SignUpResult,
   Error,
-  SignUpParams,
+  SignUpBody,
   unknown
 > => {
   const key = queryKey.auth.signup();
-  const mutation = useMutation<SignUpResult, Error, SignUpParams, unknown>(
+  const mutation = useMutation<SignUpResult, Error, SignUpBody, unknown>(
     key,
     signUp,
   );

--- a/client/src/lib/hooks/mutations/auth.ts
+++ b/client/src/lib/hooks/mutations/auth.ts
@@ -1,0 +1,23 @@
+import type { SignUpParams } from '@/lib/api/auth';
+import type { UseMutationResult } from '@tanstack/react-query';
+import type { SignUpResult } from 'shared';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { signUp } from '@/lib/api/auth';
+import { queryKey } from '@/lib/constants';
+
+// TODO: Error 타입은 Api Error랑 error instanceof SyntaxError
+export const useSignUpMutation = (): UseMutationResult<
+  SignUpResult,
+  Error,
+  SignUpParams,
+  unknown
+> => {
+  const key = queryKey.auth.signup();
+  const mutation = useMutation<SignUpResult, Error, SignUpParams, unknown>(
+    key,
+    signUp,
+  );
+  return mutation;
+};

--- a/client/src/mocks/handlers/auth.ts
+++ b/client/src/mocks/handlers/auth.ts
@@ -1,15 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import type { SignUpParams } from '@/lib/api/auth';
-import type { SignUpResponse } from 'shared';
+import type { SignUpResponse, SignUpBody } from 'shared';
 
 import { rest } from 'msw';
 
 import { apiUrl } from '@/lib/constants';
 
-export const signUp = rest.post<SignUpParams, never, SignUpResponse>(
+export const signUp = rest.post<SignUpBody, never, SignUpResponse>(
   apiUrl.auth.signup(),
   async (req, res, ctx) => {
-    const { nickname }: SignUpParams = await req.json();
+    const { nickname }: SignUpBody = await req.json();
 
     return res(
       ctx.status(200),

--- a/client/src/mocks/handlers/auth.ts
+++ b/client/src/mocks/handlers/auth.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import type { SignUpParams } from '@/lib/api/auth';
+import type { SignUpResponse } from 'shared';
+
+import { rest } from 'msw';
+
+import { apiUrl } from '@/lib/constants';
+
+export const signUp = rest.post<SignUpParams, never, SignUpResponse>(
+  apiUrl.auth.signup(),
+  async (req, res, ctx) => {
+    const { nickname }: SignUpParams = await req.json();
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        statusCode: 200,
+        result: { message: `${nickname}이 회원가입에 성공했다` },
+      }),
+    );
+  },
+);

--- a/client/src/mocks/handlers/index.ts
+++ b/client/src/mocks/handlers/index.ts
@@ -1,3 +1,7 @@
+import * as authHandlers from '@/mocks/handlers/auth';
 import * as userHandlers from '@/mocks/handlers/user';
 
-export const handlers = [...Object.values(userHandlers)];
+export const handlers = [
+  ...Object.values(userHandlers),
+  ...Object.values(authHandlers),
+];

--- a/client/src/pages/SignUp.tsx
+++ b/client/src/pages/SignUp.tsx
@@ -1,15 +1,29 @@
+import type { FormEvent } from 'react';
+
 import React from 'react';
 
 import { Link } from 'react-router-dom';
 
 import Button from '@/components/Button';
 import LabelInput from '@/components/LabelInput';
+import { useSignUpMutation } from '@/lib/hooks/mutations/auth';
 
 function Signup(): JSX.Element {
+  const mutation = useSignUpMutation();
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>): void => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const id = formData.get('id') as string;
+    const password = formData.get('password') as string;
+    const nickname = formData.get('nickname') as string;
+    mutation.mutate({ username: id, password, nickname });
+  };
+
   return (
     <div className="mx-auto flex h-full max-w-xl flex-col items-center justify-center px-9">
       <div className="mb-14 text-3xl font-bold">toquiz</div>
-      <form className="flex w-full flex-col gap-8">
+      <form className="flex w-full flex-col gap-8" onSubmit={handleSubmit}>
         <div className="flex flex-col gap-5">
           <LabelInput
             label="아이디"
@@ -38,7 +52,9 @@ function Signup(): JSX.Element {
             placeholder="닉네임을 입력하세요"
           />
         </div>
-        <Button className="w-full">회원가입</Button>
+        <Button type="submit" className="w-full">
+          회원가입
+        </Button>
       </form>
       <div className="mt-2">
         계정이 있나요?{' '}

--- a/shared/src/api/index.ts
+++ b/shared/src/api/index.ts
@@ -1,0 +1,2 @@
+export * from './users';
+export * from './response';

--- a/shared/src/api/users/auth/signup.ts
+++ b/shared/src/api/users/auth/signup.ts
@@ -1,10 +1,9 @@
 import { type SuccessResponse } from '@api/response';
-import { type User } from '@api/users/domain';
 
 export interface SignUpBody {
-  username: User['username'];
-  password: User['password'];
-  nickname: User['nickname'];
+  username: string;
+  password: string;
+  nickname: string;
 }
 
 export interface SignUpResult {

--- a/shared/src/api/users/index.ts
+++ b/shared/src/api/users/index.ts
@@ -1,0 +1,2 @@
+export * from './auth/index';
+export * from './domain';

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from './api/index';


### PR DESCRIPTION
## 🤷‍♂️ Description
- #20 

<!-- 구현하고자 하는 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] `POST /api/auth/signup` mock API 작성
- [X] `POST /api/auth/signup` API 요청 함수 작성
- [X] `POST /api/auth/signup` API 뮤테이션 훅 작성
- [X] 회원가입 페이지 `회원가입` 버튼에 `POST /api/auth/signup` API 연동