### PR TITLE
feat: toquiz token 발급 로직

### DIFF
--- a/server/apps/api/src/users/users.controller.ts
+++ b/server/apps/api/src/users/users.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Post, Req, Res, UseGuards } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { LoginDto, SignUpDto } from './dto';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
-import { LogInResult, RefreshResult, SignUpResult } from 'shared';
+import { IssueToquizCookieResult, LogInResult, RefreshResult, SignUpResult } from 'shared';
 import { Request, Response } from 'express';
 import { cookieOption } from 'libs/utils/cookie-option';
 import { JwtRefreshGuard } from 'libs/common/guards/jwt-refresh.guard';
@@ -26,9 +26,12 @@ export class UsersController {
     @Body() loginDto: LoginDto,
     @Res({ passthrough: true }) res: Response,
   ): Promise<LogInResult> {
-    const { user, accessToken, refreshToken } = await this.usersService.login(loginDto);
+    const { user, accessToken, refreshToken, toquizUserId } = await this.usersService.login(
+      loginDto,
+    );
 
     res.cookie('refreshToken', refreshToken, cookieOption.refreshToken);
+    res.cookie('toquizToken', toquizUserId, cookieOption.toquizToken);
 
     return {
       user: {
@@ -60,5 +63,17 @@ export class UsersController {
       },
       accessToken,
     };
+  }
+
+  @Post('/auth/toquiz')
+  async issueToquizCookie(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<IssueToquizCookieResult> {
+    const toquizUserId = await this.usersService.issueToquizCookie(req?.cookies?.toquizUserId);
+
+    res.cookie('toquizUserId', toquizUserId, cookieOption.refreshToken);
+
+    return { message: 'toquizToken 발급 성공' };
   }
 }

--- a/server/libs/prisma/prisma/mongodb.schema.prisma
+++ b/server/libs/prisma/prisma/mongodb.schema.prisma
@@ -17,8 +17,9 @@ type Panel {
   questions String[]
 }
 
-model AnonymousUser {
+model ToquizUser {
   id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  userId    String?
   panels    Panel[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/server/libs/utils/cookie-option/cookie-option.ts
+++ b/server/libs/utils/cookie-option/cookie-option.ts
@@ -10,4 +10,8 @@ export const cookieOption = {
     secure: true,
     maxAge: 1000 * 60 * 60 * 24 * 14, // 14일 동안 유지
   },
+  toquizToken: {
+    secure: true,
+    maxAge: 1000 * 60 * 60 * 24 * 365, // 1년 동안 유지
+  },
 };


### PR DESCRIPTION
## 🤷‍♂️ Description
- close #49

## 📝 Primary Commits

- mongoDB 스키마 userId 필드 추가 (로그인된 User와 Toquiz User간 매핑을 위해)
- toquizToken 발급 로직
  - 회원가입 -> mongoDB에 활동정보를 저장할 toquizUser 도큐먼트 생성
  - 로그인 -> 회원가입때 생성한 toquizUser 도큐먼트의 id를 toquizToken 으로 발급
  - 익명 사용자 -> toquizUser 도큐먼트 생성 및 toquizToken 발급

## 📷 Screenshots
<img width="458" alt="스크린샷 2023-03-14 오후 2 59 17" src="https://user-images.githubusercontent.com/72093196/224909643-ee1fa272-5113-4ff4-ac7a-41dc30e9e99d.png">

