### PR TITLE
feat: 질문 생성 관련 shared 공통 인터페이스

### DIFF
--- a/shared/src/api/index.ts
+++ b/shared/src/api/index.ts
@@ -1,4 +1,5 @@
-export * from './panels';
-export * from './users';
 export * from './url';
 export * from './response';
+export * from './users';
+export * from './panels';
+export * from './questions';

--- a/shared/src/api/questions/create-question.ts
+++ b/shared/src/api/questions/create-question.ts
@@ -1,0 +1,10 @@
+import type { Question } from '../../libs';
+import type { SuccessResponse } from '../response';
+
+export interface CreateQuestionBody {
+  content: Question['content'];
+}
+
+export interface CreateQuestionResult extends Question {}
+
+export type CreateQuestionResponse = SuccessResponse<CreateQuestionResult>;

--- a/shared/src/api/questions/index.ts
+++ b/shared/src/api/questions/index.ts
@@ -1,0 +1,1 @@
+export * from './create-question';

--- a/shared/src/libs/domains/index.ts
+++ b/shared/src/libs/domains/index.ts
@@ -1,3 +1,4 @@
 export * from './user';
 export * from './panel';
 export * from './toquiz-user';
+export * from './question';

--- a/shared/src/libs/domains/question.ts
+++ b/shared/src/libs/domains/question.ts
@@ -1,0 +1,11 @@
+export interface Question {
+  id: string;
+  panelId: string;
+  toquizUserId: string;
+  content: string;
+  answerNum: number;
+  likeNum: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}

--- a/shared/src/libs/domains/toquiz-user.ts
+++ b/shared/src/libs/domains/toquiz-user.ts
@@ -1,5 +1,5 @@
 interface Panel {
-  panelId: number;
+  panelId: string;
   likes: string[];
   questions: string[];
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
- #101 
- shared 폴더의 공통 인터페이스 구현

## 📝 Primary Commits

- `question` 도메인 구현
- `create-question` 요청, 응답 폼 구현
- `toquiz-user`의 panelId 타입 수정 (number -> string)
