### PR TITLE
feat: 패널 질문 받아오는 로직

### DIFF
--- a/server/apps/api/src/questions/questions.controller.ts
+++ b/server/apps/api/src/questions/questions.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { QuestionsService } from '@api/src/questions/questions.service';
+import { GetPanelQuestionsResult, Question } from 'shared';
+
+@Controller('api/panels/:panelId/questions')
+export class QuestionsController {
+  constructor(private questionsService: QuestionsService) {}
+
+  @Get()
+  async getPanelQuestions(
+    @Param('panelId') panelId: Question['panelId'],
+    @Query('cursor') cursor?: Question['id'],
+  ): Promise<GetPanelQuestionsResult> {
+    return await this.questionsService.getPanelQuestions(panelId, cursor);
+  }
+}

--- a/server/apps/api/src/questions/questions.module.ts
+++ b/server/apps/api/src/questions/questions.module.ts
@@ -3,10 +3,11 @@ import { QuestionController } from '@api/src/questions/question.controller';
 import { AuthModule } from 'libs/common/authorization/auth.module';
 import { QuestionsService } from '@api/src/questions/questions.service';
 import { QuestionsRepository } from '@api/src/questions/questions.repository';
+import { QuestionsController } from '@api/src/questions/questions.controller';
 
 @Module({
   imports: [AuthModule],
-  controllers: [QuestionController],
+  controllers: [QuestionController, QuestionsController],
   providers: [QuestionsService, QuestionsRepository],
 })
 export class QuestionsModule {}

--- a/server/apps/api/src/questions/questions.repository.ts
+++ b/server/apps/api/src/questions/questions.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { MysqlPrismaService } from 'libs/prisma/src/mysql-prisma.service';
 import { MongodbPrismaService } from 'libs/prisma/src/mongodb-prisma.service';
 import { CreateQuestionDto } from '@api/src/questions/dto';
-import { Question } from 'shared';
+import { PAGENUM, Question } from 'shared';
 
 @Injectable()
 export class QuestionsRepository {
@@ -49,5 +49,26 @@ export class QuestionsRepository {
         },
       });
     }
+  }
+
+  async getQuestionsFirstPage(panelId: Question['panelId']): Promise<Question[]> {
+    return await this.mysqlService.question.findMany({
+      take: PAGENUM,
+      where: { panelId: panelId },
+      orderBy: [{ createdAt: 'desc' }],
+    });
+  }
+
+  async getQuestionsNextPage(
+    panelId: Question['panelId'],
+    cursor: Question['id'],
+  ): Promise<Question[]> {
+    return await this.mysqlService.question.findMany({
+      skip: 1,
+      take: PAGENUM,
+      cursor: { id: cursor },
+      where: { panelId: panelId },
+      orderBy: { createdAt: 'desc' },
+    });
   }
 }

--- a/server/apps/api/src/questions/questions.service.ts
+++ b/server/apps/api/src/questions/questions.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { CreateQuestionDto } from '@api/src/questions/dto';
-import { Question } from 'shared';
+import { GetPanelQuestionsResult, Question } from 'shared';
 import { QuestionsRepository } from '@api/src/questions/questions.repository';
 
 @Injectable()
@@ -13,5 +13,18 @@ export class QuestionsService {
     await this.questionsRepository.insertQuestionToToquizUser(panelId, question.id, toquizUserId);
 
     return question;
+  }
+
+  async getPanelQuestions(
+    panelId: Question['panelId'],
+    cursor: Question['id'] | null,
+  ): Promise<GetPanelQuestionsResult> {
+    let questions: Question[];
+    if (cursor) questions = await this.questionsRepository.getQuestionsNextPage(panelId, cursor);
+    else questions = await this.questionsRepository.getQuestionsFirstPage(panelId);
+
+    const nextCursor = questions?.at(-1)?.id;
+
+    return { questions, nextCursor };
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
- close #112 

## 📝 Primary Commits

- `repository`
  - `getQuestionsFirstPage`: 최초로 패널 질문 받아올 경우 호출 (cursor 없음)
  - `getQuestionsNextPage`: 이전에 패널 질문을 받은적이 있는 경우 호출 (cursor 있음)
- `service`
  - `getPanelQuestions`
    - repository에서 질문목록 받아옴
    - 받아온 질문 목록을 바탕으로 nextCursor 생성(nextCursor: 받아온 질문의 가장 마지막 id)
- `controller`
  - GET `api/panels/:panelId/questions/?cursor`

## 📷 Screenshots
<img width="548" alt="스크린샷 2023-03-19 오후 8 37 18" src="https://user-images.githubusercontent.com/72093196/226172724-6d822f30-166d-4ad7-bdff-de7b162bbb93.png">
