### PR TITLE
Feat/117 like question

### DIFF
--- a/server/apps/api/src/questions/dto/index.ts
+++ b/server/apps/api/src/questions/dto/index.ts
@@ -1,1 +1,2 @@
 export * from './create-question.dto';
+export * from './like-question.dto';

--- a/server/apps/api/src/questions/dto/like-question.dto.ts
+++ b/server/apps/api/src/questions/dto/like-question.dto.ts
@@ -1,0 +1,20 @@
+import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
+import { Question } from 'shared';
+
+export class LikeQuestionDto {
+  @IsString()
+  @IsNotEmpty()
+  panelId: Question['panelId'];
+
+  @IsString()
+  @IsNotEmpty()
+  questionId: Question['id'];
+
+  @IsString()
+  @IsNotEmpty()
+  toquizUserId: Question['toquizUserId'];
+
+  @IsBoolean()
+  @IsNotEmpty()
+  like: boolean;
+}

--- a/server/apps/api/src/questions/questions.controller.ts
+++ b/server/apps/api/src/questions/questions.controller.ts
@@ -1,6 +1,9 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
 import { QuestionsService } from '@api/src/questions/questions.service';
-import { GetPanelQuestionsResult, Question } from 'shared';
+import { GetPanelQuestionsResult, LikeQuestionResult, Question } from 'shared';
+import { ReceivedData } from 'libs/common/decorators/ReceivedData.decorator';
+import { ToquizGuard } from 'libs/common/guards/toquiz.guard';
+import { LikeQuestionDto } from '@api/src/questions/dto';
 
 @Controller('api/panels/:panelId/questions')
 export class QuestionsController {
@@ -12,5 +15,14 @@ export class QuestionsController {
     @Query('cursor') cursor?: Question['id'],
   ): Promise<GetPanelQuestionsResult> {
     return await this.questionsService.getPanelQuestions(panelId, cursor);
+  }
+
+  @Post(':questionId/like')
+  @UseGuards(ToquizGuard)
+  async likeQuestion(
+    @ReceivedData() likeQuestionDto: LikeQuestionDto,
+  ): Promise<LikeQuestionResult> {
+    await this.questionsService.likeQuestion(likeQuestionDto);
+    return { message: 'success to like' };
   }
 }

--- a/server/apps/api/src/questions/questions.service.ts
+++ b/server/apps/api/src/questions/questions.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { CreateQuestionDto } from '@api/src/questions/dto';
+import { CreateQuestionDto, LikeQuestionDto } from '@api/src/questions/dto';
 import { GetPanelQuestionsResult, Question } from 'shared';
 import { QuestionsRepository } from '@api/src/questions/questions.repository';
 
@@ -8,13 +8,10 @@ export class QuestionsService {
   constructor(private questionsRepository: QuestionsRepository) {}
 
   async createQuestion(createQuestionDto: CreateQuestionDto): Promise<Question> {
-    const { panelId, toquizUserId } = createQuestionDto;
+    const { toquizUserId, panelId } = createQuestionDto;
     const question = await this.questionsRepository.createQuestion(createQuestionDto);
 
-    const user = await this.questionsRepository.getPanelsByToquizUserId(toquizUserId);
-    const existingPanel = user.panels.find((panel) => panel.panelId === panelId);
-
-    if (existingPanel) {
+    if (await this.isExistPanelSession(toquizUserId, panelId)) {
       await this.questionsRepository.insertQuestionToToquizUser(panelId, question.id, toquizUserId);
     } else {
       await this.questionsRepository.insertQuestionToToquizUserFirst(
@@ -38,5 +35,47 @@ export class QuestionsService {
     const nextCursor = questions?.at(-1)?.id;
 
     return { questions, nextCursor };
+  }
+
+  async likeQuestion(likeQuestionDto: LikeQuestionDto): Promise<void> {
+    likeQuestionDto.like
+      ? await this.insertLike(likeQuestionDto)
+      : await this.removeLike(likeQuestionDto);
+  }
+
+  async insertLike(likeQuestionDto: LikeQuestionDto): Promise<void> {
+    const { toquizUserId, panelId, questionId } = likeQuestionDto;
+
+    if (await this.isExistPanelSession(toquizUserId, panelId)) {
+      await this.questionsRepository.insertLikeToToquizUser(likeQuestionDto);
+    } else {
+      await this.questionsRepository.insertLikeToToquizUserFirst(likeQuestionDto);
+    }
+
+    await this.questionsRepository.incrementLikeNumToQuestion(questionId);
+  }
+
+  async removeLike(likeQuestionDto: LikeQuestionDto): Promise<void> {
+    const { toquizUserId, panelId, questionId } = likeQuestionDto;
+
+    const panels = await this.questionsRepository.getPanelLikesOfToquizUser(toquizUserId);
+    const likes = panels.find((panel) => panel.panelId === panelId).likes;
+
+    await this.questionsRepository.updateLikeToToquizUser(
+      likeQuestionDto,
+      likes.filter((id) => id != questionId),
+    );
+
+    await this.questionsRepository.decrementLikeNumToQuestion(questionId);
+  }
+
+  async isExistPanelSession(
+    toquizUserId: Question['toquizUserId'],
+    panelId: Question['panelId'],
+  ): Promise<boolean> {
+    const user = await this.questionsRepository.getPanelsByToquizUserId(toquizUserId);
+    const existingPanel = user.panels.find((panel) => panel.panelId === panelId);
+
+    return Boolean(existingPanel);
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
- close #117 
- 질문 및 좋아요를 생성할 때, 패널 활동 정보가 있는 지 여부를 검증하는 로직이 매번 필요한데, 이 부분을 패널 정보 받아올 때 toquizUser의 panels 배열에 `{id, likes:[], questions:[]}`을 생성하는 식으로 구현하여 검증을 하지 않아도 되도록 리팩토링 할 예정입니다.

## 📝 Primary Commits
- `repository`
  - like: `true`
    - 유저의 첫 활동 시 배열 생성 필요 -> 로직 분할
      - `insertLikeToToquizUserFirst`
      - `insertLikeToToquizUser`
    - `incrementLikeNumToQuestion`
  - like: `false`
    - 좋아요를 누른 질문 목록을 가져와서 filtering 후 업데이트
    - `getPanelLikesOfToquizUser`
    - `updateLikeToToquizUser`
    - `decrementLikeNumToQuestion`
- `service`
  - `insertLike`
    - 패널 활동 정보가 있는 지 확인
    - 패널 활동 정보가 있으면 -> likes 배열에 추가
    - 패널 활동 정보가 없으면 -> panels 배열에 likes 배열 추가
    - `incrementLikeNumToQuestion`을 통해 Question 테이블의 likeNum 1 증가
  - `removeLike`
    - `getPanelLikesOfToquizUser`를 통해 panel의 likes 활동 정보 받아옴
    - 받아온 likes 활동 정보에서 questionId가 같은 것 지우기 (필터링)
    - `updateLikeToToquizUser`를 통해 panel의 likes 활동 정보 업데이트
    - `dncrementLikeNumToQuestion`을 통해 Question 테이블의 likeNum 1 감소
- `controller`
  - POST `api/panels/:panelId/questions/:questionId/like`

## 📷 Screenshots
<img width="352" alt="스크린샷 2023-03-21 오후 5 31 04" src="https://user-images.githubusercontent.com/72093196/226552960-bc5c40c4-51da-42fb-9860-e09fdeddce73.png">
