### PR TITLE
cicd: `yarn install` 커맨드에서 옵션을 제거한다

### DIFF
--- a/.github/workflows/test.fe.yml
+++ b/.github/workflows/test.fe.yml
@@ -24,13 +24,13 @@ jobs:
           node-version: ${{ matrix.node }}
       
       - name: Install shared dependencies
-        run: yarn shared install --immutable --immutable-cache --check-cache
+        run: yarn shared install
       
       - name: Build shared code
         run: yarn shared build
       
       - name: Install client dependencies
-        run: yarn client install --immutable --immutable-cache --check-cache
+        run: yarn client install
         
       - name: Build production bundle
         run: yarn client build


### PR DESCRIPTION
## 🤷‍♂️ Description
- #161 

`yarn install --immutable --immutable-cache --check-cache`이 정확히 무엇인지 모르므로 삭제하고 돌려본다
