### PR TITLE
[Client, Common] `shared` 패키지에서 esm 지원을 삭제한다

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -20,6 +20,14 @@ export default defineConfig(({ mode }) => {
           eslint: { lintCommand: 'eslint "./src/**/*.{ts,tsx}"' },
         }),
     ],
+    optimizeDeps: {
+      include: ['shared'],
+    },
+    build: {
+      commonjsOptions: {
+        include: [/shared/, /node_modules/],
+      },
+    },
     server: {
       proxy: mode === 'proxy' && {
         '/api': {

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,25 +1,12 @@
 {
   "name": "shared",
   "version": "1.0.0",
-  "main": "dist/cjs/index.js",
-  "exports": {
-    ".": {
-      "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
-      },
-      "import": {
-        "default": "./dist/esm/index.js",
-        "types": "./dist/esm/index.d.ts"
-      }
-    }
-  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "license": "MIT",
   "scripts": {
     "prebuild": "rm -rf dist",
-    "build": "yarn build:cjs & yarn build:esm",
-    "build:cjs": "tsc -p tsconfig.cjs.json",
-    "build:esm": "tsc -p tsconfig.esm.json",
+    "build": "tsc",
     "lint": "eslint \"src/**/*.ts\" --fix"
   },
   "devDependencies": {

--- a/shared/tsconfig.cjs.json
+++ b/shared/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "dist/cjs"
-  }
-}

--- a/shared/tsconfig.esm.json
+++ b/shared/tsconfig.esm.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "ESNext",
-    "outDir": "dist/esm"
-  }
-}

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "target": "es2016",
     "lib": ["ESNext"],
+    "module": "commonjs",
+    "outDir": "dist",
     "moduleResolution": "node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -12,7 +14,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "removeComments": true,
-    "incremental": true,
+    "incremental": true
   },
-  "include": ["src"],
+  "include": ["src"]
 }


### PR DESCRIPTION
## 🤷‍♂️ Description
- #170 

<!-- 구현하고자 하는 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] `shared` 패키지에서 esm 지원 삭제
- [X] `shared` 패키지가 이제 cjs로만 빌드되므로 `client` 패키지가 사용하는 Vite에 모노 레포로 연결된 cjs 의존성 관련 설정

close #170 