### PR TITLE
fix: `<MemoryRouter />`로 `<Link />` 컴포넌트를 감싼다

### DIFF
--- a/client/src/pages/Main.test.tsx
+++ b/client/src/pages/Main.test.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 
 import { screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { renderWithQueryClient } from '@/lib/test-utils';
 import Main from '@/pages/Main';
 
 describe('메인 페이지', () => {
   it('사용자가 작성한 패널의 목록을 보여준다.', async () => {
-    renderWithQueryClient(<Main />);
+    renderWithQueryClient(
+      <MemoryRouter>
+        <Main />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('무엇이든 물어보세요')).toBeInTheDocument();


### PR DESCRIPTION


## 🤷‍♂️ Description
- #169
- `<Link />` 컴포넌트는 router context 안에 있어야한다.
<!-- 구현하고자 하는 기능에 대해 작성해 주세요. -->


<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

close #169