### PR TITLE
build: `cross-fetch`를 devDependencies로 옮긴다

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.24.4",
-    "cross-fetch": "^3.1.5",
     "detect-node": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -41,6 +40,7 @@
     "@vitest/coverage-c8": "^0.29.2",
     "@vitest/ui": "^0.29.2",
     "autoprefixer": "^10.4.13",
+    "cross-fetch": "^3.1.5",
     "eslint": "^8.33.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-config-standard-with-typescript": "^34.0.0",


### PR DESCRIPTION


## 🤷‍♂️ Description
- #127 

- `cross-fetch`는 Node.js 18 + MSW를 사용하기 위한 폴리필로, 테스트 환경에서만 사용하므로 devDependencies로 옮긴다.
- #124 를 참고한다

<!-- 구현하고자 하는 기능에 대해 작성해 주세요. -->

close #127
