### PR TITLE
feat: 메인 페이지 패널 리스트에 무한 스크롤을 적용한다 

### DIFF
--- a/client/src/pages/Main.test.tsx
+++ b/client/src/pages/Main.test.tsx
@@ -18,6 +18,13 @@ describe('메인 페이지', () => {
     };
   });
 
+  // TODO: 모킹 함수 따로 빼기
+  window.IntersectionObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+
   it('내 패널 모아보기 헤딩을 보여준다.', async () => {
     renderWithQueryClient(
       <MemoryRouter>


### PR DESCRIPTION
## 🤷‍♂️ Description
- #189

<!-- 구현하고자 하는 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [X] `useInfiniteQuery` API와 `useInView` 커스텀 훅 사용하여 무한 스크롤 적용

## 📷 Screenshots

![panel list](https://user-images.githubusercontent.com/57662010/235455856-c40193b7-955a-4c3d-9a4a-fd03be3c2314.gif)


<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

close #189