### PR TITLE
refactor: 메인 페이지에서 패널 목록과 로직을 `InfinitePanelGrid`로 분리한다

### DIFF
--- a/client/src/components/panel/InfinitePanelGrid.tsx
+++ b/client/src/components/panel/InfinitePanelGrid.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react';
+
+import PanelItem from '@/components/panel/PanelItem';
+import { useMyPanelsInfiniteQuery } from '@/hooks/panel';
+import useInView from '@/hooks/useInView';
+
+const InfinitePanelGrid = (): JSX.Element => {
+  const panelsQuery = useMyPanelsInfiniteQuery();
+  const [fetchMoreRef, inView] = useInView();
+
+  useEffect(() => {
+    if (!inView || panelsQuery.isFetchingNextPage || !panelsQuery.hasNextPage)
+      return;
+    panelsQuery.fetchNextPage();
+  }, [inView, panelsQuery]);
+
+  if (panelsQuery.isLoading) return <div>loading...</div>;
+  if (panelsQuery.isError) return <div>error occurred</div>;
+
+  return (
+    <>
+      <ul className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {panelsQuery.data.pages.map((page) =>
+          page.panels.map((panel) => (
+            <PanelItem key={panel.id} panel={panel} />
+          )),
+        )}
+      </ul>
+      <div ref={fetchMoreRef} />
+    </>
+  );
+};
+
+export default InfinitePanelGrid;

--- a/client/src/pages/Main.test.tsx
+++ b/client/src/pages/Main.test.tsx
@@ -25,28 +25,24 @@ describe('메인 페이지', () => {
     disconnect: vi.fn(),
   }));
 
-  it('내 패널 모아보기 헤딩을 보여준다.', async () => {
+  it('내 패널 모아보기 헤딩을 보여준다.', () => {
     renderWithQueryClient(
       <MemoryRouter>
         <Main />
       </MemoryRouter>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole('heading')).toHaveTextContent('내 패널 모아보기');
-    });
+    expect(screen.getByRole('heading')).toHaveTextContent('내 패널 모아보기');
   });
 
-  it('사용자의 닉네임을 보여준다.', async () => {
+  it('사용자의 닉네임을 보여준다.', () => {
     renderWithQueryClient(
       <MemoryRouter>
         <Main />
       </MemoryRouter>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByText(/테스트 닉네임/i)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/테스트 닉네임/i)).toBeInTheDocument();
   });
 
   it('사용자가 작성한 패널의 목록을 보여준다.', async () => {

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -1,14 +1,12 @@
 import type { LoaderFunction } from 'react-router-dom';
 
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { redirect } from 'react-router-dom';
 
 import HomeHeader from '@/components/home/HomeHeader';
-import PanelItem from '@/components/panel/PanelItem';
-import { useMyPanelsInfiniteQuery } from '@/hooks/panel';
+import InfinitePanelGrid from '@/components/panel/InfinitePanelGrid';
 import { useUserStore } from '@/hooks/store/useUserStore';
-import useInView from '@/hooks/useInView';
 import { isUserLoggedIn } from '@/lib/routeGuard';
 
 // https://reactrouter.com/en/main/fetch/redirect
@@ -20,18 +18,7 @@ export const mainLoader: LoaderFunction = async () => {
 };
 
 const Main = (): JSX.Element => {
-  const panelsQuery = useMyPanelsInfiniteQuery();
   const user = useUserStore((state) => state.user);
-  const [fetchMoreRef, inView] = useInView();
-
-  useEffect(() => {
-    if (!inView || panelsQuery.isFetchingNextPage || !panelsQuery.hasNextPage)
-      return;
-    panelsQuery.fetchNextPage();
-  }, [inView, panelsQuery]);
-
-  if (panelsQuery.isLoading) return <div>loading...</div>;
-  if (panelsQuery.isError) return <div>error occurred</div>;
 
   return (
     <div className="flex h-full w-full flex-col">
@@ -54,14 +41,7 @@ const Main = (): JSX.Element => {
               <span className="text-grey-dark text-sm">내 패널</span>
             </div>
             <div className="bg-off-white flex-1 px-3 pt-4 pb-16">
-              <ul className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-                {panelsQuery.data.pages.map((page) =>
-                  page.panels.map((panel) => (
-                    <PanelItem key={panel.id} panel={panel} />
-                  )),
-                )}
-              </ul>
-              <div ref={fetchMoreRef} />
+              <InfinitePanelGrid />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 🤷‍♂️ Description
- #196 

close #196
