### PR TITLE
fix: `splice` 대신 `slice`를 써서 패널 리스트 mock 데이터 원본에 변경이 없도록 한다

### DIFF
--- a/client/src/mocks/handlers/panel.ts
+++ b/client/src/mocks/handlers/panel.ts
@@ -23,7 +23,7 @@ export const getMyPanels = rest.get<never, never, GetMyPanelsResponse>(
 
     const start = Number(nextCursor);
     const end = start + 20;
-    const newPanelData = myPanelsData.splice(start, end);
+    const newPanelData = myPanelsData.slice(start, end);
 
     let newNextCursor: undefined | Panel['id'];
     if (end >= myPanelsData.length) newNextCursor = undefined;


### PR DESCRIPTION
## 🤷‍♂️ Description
- #194 

close #194 
