### PR TITLE
[액션 메뉴] 바텀 시트 형태가 기본인 ActionMenuController를 만든다

### DIFF
--- a/src/components/system/ActionMenuController.tsx
+++ b/src/components/system/ActionMenuController.tsx
@@ -1,0 +1,48 @@
+import type { CreateOverlayContent } from '@/hooks/useOverlay';
+
+import React, { useRef, useEffect } from 'react';
+
+export interface ActionMenuControllerOptions {
+  backdrop?: boolean;
+}
+
+export function ActionMenuController({
+  createActionMenuContent: ActionMenuContent,
+  close,
+  backdrop = true,
+}: ActionMenuControllerOptions & {
+  createActionMenuContent: CreateOverlayContent;
+  close: () => void;
+}): JSX.Element {
+  const actionMenu = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleOutsideClick(event: MouseEvent): void {
+      if (
+        event.target instanceof Node &&
+        actionMenu.current?.contains(event.target)
+      )
+        return;
+
+      close();
+    }
+
+    window.addEventListener('mousedown', handleOutsideClick);
+    return () => {
+      window.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [close]);
+
+  return (
+    <>
+      {backdrop && <div className="fixed inset-0 bg-backdrop" />}
+      <div
+        ref={actionMenu}
+        role="dialog"
+        className={`fixed bottom-0 left-0 w-full`}
+      >
+        <ActionMenuContent close={close} />
+      </div>
+    </>
+  );
+}

--- a/src/components/system/ActionMenuController.tsx
+++ b/src/components/system/ActionMenuController.tsx
@@ -1,6 +1,8 @@
 import type { CreateOverlayContent } from '@/hooks/useOverlay';
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
+
+import { useOutsideClick } from '@/hooks/useOutsideClick';
 
 export interface ActionMenuControllerOptions {
   backdrop?: boolean;
@@ -16,22 +18,7 @@ export function ActionMenuController({
 }): JSX.Element {
   const actionMenu = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    function handleOutsideClick(event: MouseEvent): void {
-      if (
-        event.target instanceof Node &&
-        actionMenu.current?.contains(event.target)
-      )
-        return;
-
-      close();
-    }
-
-    window.addEventListener('mousedown', handleOutsideClick);
-    return () => {
-      window.removeEventListener('mousedown', handleOutsideClick);
-    };
-  }, [close]);
+  useOutsideClick(actionMenu, close);
 
   return (
     <>

--- a/src/components/system/ModalController.tsx
+++ b/src/components/system/ModalController.tsx
@@ -1,12 +1,6 @@
+import type { CreateOverlayContent } from '@/hooks/useOverlay';
+
 import React, { useRef, useEffect } from 'react';
-
-export interface CreateModalContentProps {
-  close: () => void;
-}
-
-export type CreateModalContent = (
-  props: CreateModalContentProps,
-) => JSX.Element;
 
 type VerticalAlignment = 'top' | 'bottom' | 'middle';
 type HorizontalAlignment = 'left' | 'right' | 'center';
@@ -36,7 +30,7 @@ export function ModalController({
   vertical = 'middle',
   horizontal = 'center',
 }: ModalControllerOptions & {
-  createModalContent: CreateModalContent;
+  createModalContent: CreateOverlayContent;
   close: () => void;
 }): JSX.Element {
   const verticalAlignment = verticalAlignments[vertical];

--- a/src/components/system/ModalController.tsx
+++ b/src/components/system/ModalController.tsx
@@ -1,6 +1,8 @@
 import type { CreateOverlayContent } from '@/hooks/useOverlay';
 
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
+
+import { useOutsideClick } from '@/hooks/useOutsideClick';
 
 type VerticalAlignment = 'top' | 'bottom' | 'middle';
 type HorizontalAlignment = 'left' | 'right' | 'center';
@@ -37,19 +39,7 @@ export function ModalController({
   const horizontalAlginment = horizontalAlignments[horizontal];
   const modal = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    function handleOutsideClick(event: MouseEvent): void {
-      if (event.target instanceof Node && modal.current?.contains(event.target))
-        return;
-
-      close();
-    }
-
-    window.addEventListener('mousedown', handleOutsideClick);
-    return () => {
-      window.removeEventListener('mousedown', handleOutsideClick);
-    };
-  }, [close]);
+  useOutsideClick(modal, close);
 
   return (
     <>

--- a/src/components/system/ModalController.tsx
+++ b/src/components/system/ModalController.tsx
@@ -53,7 +53,7 @@ export function ModalController({
 
   return (
     <>
-      {backdrop && <div className="fixed inset-0 bg-Modal" />}
+      {backdrop && <div className="fixed inset-0 bg-backdrop" />}
       <div
         ref={modal}
         role="dialog"

--- a/src/components/system/__tests__/ActionMenuController.test.tsx
+++ b/src/components/system/__tests__/ActionMenuController.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ActionMenuController } from '@/components/system/ActionMenuController';
+
+describe('ActionMenuController', () => {
+  const handleClose = vi.fn();
+
+  it('액션 메뉴 안쪽을 누르면 close 함수가 호출되지 않는다', async () => {
+    render(
+      <ActionMenuController
+        createActionMenuContent={() => <div>액션 메뉴</div>}
+        close={handleClose}
+      />,
+    );
+
+    const overlay = screen.getByText(/액션 메뉴/);
+    await userEvent.click(overlay);
+
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+
+  it('액션 메뉴 바깥을 누르면 close 함수가 호출된다', async () => {
+    render(
+      <ActionMenuController
+        createActionMenuContent={() => <>오버레이</>}
+        close={handleClose}
+      />,
+    );
+
+    await userEvent.click(document.body);
+
+    expect(handleClose).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useOutsideClick.test.tsx
+++ b/src/hooks/__tests__/useOutsideClick.test.tsx
@@ -1,0 +1,31 @@
+import React, { useRef } from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { useOutsideClick } from '@/hooks/useOutsideClick';
+
+describe('useOutsideClick', () => {
+  const handleOutsideClick = vi.fn();
+
+  function TestComponent(): JSX.Element {
+    const target = useRef<HTMLDivElement>(null);
+
+    useOutsideClick(target, handleOutsideClick);
+    return <div ref={target}>타겟</div>;
+  }
+
+  it('target 내부를 클릭하면 onOutsideClick 함수가 호출되지 않는다', async () => {
+    render(<TestComponent />);
+
+    await userEvent.click(screen.getByText(/타겟/));
+    expect(handleOutsideClick).not.toHaveBeenCalled();
+  });
+
+  it('target 외부를 클릭하면 onOutsideClick 함수가 호출된다', async () => {
+    render(<TestComponent />);
+
+    await userEvent.click(document.body);
+    expect(handleOutsideClick).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,25 @@
+import type React from 'react';
+
+import { useEffect } from 'react';
+
+export const useOutsideClick = (
+  target: React.RefObject<HTMLElement>,
+  onOutsideClick: (event?: MouseEvent) => void,
+): void => {
+  useEffect(() => {
+    function handleOutsideClick(event: MouseEvent): void {
+      if (
+        event.target instanceof Node &&
+        target.current?.contains(event.target)
+      )
+        return;
+
+      onOutsideClick(event);
+    }
+
+    window.addEventListener('mousedown', handleOutsideClick);
+    return () => {
+      window.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [onOutsideClick, target]);
+};

--- a/src/hooks/useOverlay.tsx
+++ b/src/hooks/useOverlay.tsx
@@ -2,16 +2,16 @@ import React, { useEffect, useContext, useMemo } from 'react';
 
 import { OverlayContext } from '@/contexts/OverlayContext';
 
-export interface CreateOveralyContentProps {
+export interface CreateOverlayContentProps {
   close: () => void;
 }
 
-export type CreateOveralyContent = (
-  props: CreateOveralyContentProps,
+export type CreateOverlayContent = (
+  props: CreateOverlayContentProps,
 ) => JSX.Element;
 
 export function useOverlay(): {
-  open: (createOveralyContent: CreateOveralyContent) => void;
+  open: (createOverlayContent: CreateOverlayContent) => void;
   close: () => void;
 } {
   const context = useContext(OverlayContext);
@@ -32,9 +32,9 @@ export function useOverlay(): {
 
   return useMemo(
     () => ({
-      open: (CreateOveralyContent) => {
+      open: (CreateOverlayContent) => {
         mount(
-          <CreateOveralyContent
+          <CreateOverlayContent
             close={() => {
               unmount();
             }}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -12,7 +12,7 @@ module.exports = {
       xl: '1200px',
     },
     colors: {
-      overlay: 'rgba(36, 36, 36, 0.45)',
+      backdrop: 'rgba(36, 36, 36, 0.45)',
       white: '#FFFFFF',
       black: '#000000',
       'off-white': '#F8F8F8',


### PR DESCRIPTION
## 🤷‍♂️ Description

- #243

<!-- 구현한 기능에 대해 작성해 주세요. -->

## 📝 Primary Commits

<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- [x] 액션 메뉴 컨텐츠는 바텀 시트로 띄워진다
- [x] `useOutsideClick` 훅으로 분리

close #243 
