### PR TITLE
[패널 페이지] 사이드바에서 패널 설명을 보여준다

### DIFF
--- a/src/components/panel/PanelSidebar.tsx
+++ b/src/components/panel/PanelSidebar.tsx
@@ -10,17 +10,18 @@ interface Props {
   panel: Panel;
 }
 export function PanelSidebar({ panel }: Props): JSX.Element {
-  const { id, title, author, createdAt } = panel;
+  const { id, title, author, createdAt, description } = panel;
   return (
     <div className="flex flex-col justify-start w-[280px] divide-y divide-grey-light">
       <div className="flex gap-4 p-5">
         <span className="w-1 bg-primary" />
         <div className="flex flex-col justify-start items-start">
-          <h2 className="text-grey-dark font-medium">{title}</h2>
+          <h2 className="font-medium">{title}</h2>
           <div className="text-grey-dark text-sm">{author}</div>
           <div className="text-grey-dark text-sm">
             {formatDateString(createdAt)}
           </div>
+          <div className="text-grey-dark text-sm mt-3">{description}</div>
         </div>
       </div>
       <div className="flex flex-col py-2">


### PR DESCRIPTION
## 🤷‍♂️ Description

- 패널 페이지 사이드바에서 패널 설명 보여준다

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->
<img src="https://github.com/blacktokkies/toquiz-client/assets/57662010/795c19da-382c-496c-895e-ac817b77f530" width="300px" />
<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!--> 