### PR TITLE
[패널 페이지] 모달에서 질문 보여준다

### DIFF
--- a/src/components/panel/QAModal.tsx
+++ b/src/components/panel/QAModal.tsx
@@ -1,11 +1,28 @@
+import type { Question } from '@/lib/api/question';
+
 import React from 'react';
 
-import { ArrowBack } from '@/components/vectors';
+import { clsx } from 'clsx';
+
+import { ArrowBack, Account, Like } from '@/components/vectors';
+import { useCurrentDate } from '@/hooks/useCurrentDate';
+import { formatDistance } from '@/lib/format-date';
 
 interface Props {
   close: () => void;
+  question: Question;
+  onLikeButtonClick: () => void;
+  isActived: boolean;
 }
-export function QAModal({ close }: Props): JSX.Element {
+
+export function QAModal({
+  close,
+  question,
+  onLikeButtonClick,
+  isActived,
+}: Props): JSX.Element {
+  const now = useCurrentDate();
+
   return (
     <div
       role="dialog"
@@ -18,6 +35,40 @@ export function QAModal({ close }: Props): JSX.Element {
           <span className="sr-only">뒤로 가기</span>
         </button>
       </header>
+      <div className="flex flex-col gap-3 p-5 w-full border border-grey-light rounded-md">
+        <div className="flex items-center justify-between">
+          <div className="flex justify-start items-center gap-1 overflow-hidden">
+            <div role="img" aria-hidden>
+              <Account className="fill-grey-darkest" />
+            </div>
+            <div className="font-bold whitespace-nowrap">익명</div>
+            <div className="text-grey-dark">
+              {formatDistance(now, new Date(question.createdAt))}
+            </div>
+            {question.answerNum ? (
+              <span className="ml-1 px-3 rounded-2xl bg-primary text-white text-sm">
+                답변 {question.answerNum}개
+              </span>
+            ) : null}
+          </div>
+          <button
+            aria-label={`좋아요 버튼, 좋아요 ${question.likeNum}개`}
+            aria-pressed={isActived}
+            className={clsx(
+              'flex itesm-center gap-2 py-1 px-2 rounded-2xl border-2 text-sm',
+              isActived
+                ? 'border-green font-bold text-green bg-green-light fill-green hover:bg-green-lighter active:opacity-80'
+                : 'border-grey-light text-grey-dark fill-grey-dark hover:bg-grey-lighter active:opacity-80',
+            )}
+            type="button"
+            onClick={onLikeButtonClick}
+          >
+            <Like className="w-5 h-5" />
+            {question.likeNum}
+          </button>
+        </div>
+        <div>{question.content}</div>
+      </div>
     </div>
   );
 }

--- a/src/components/panel/QAModal.tsx
+++ b/src/components/panel/QAModal.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { ArrowBack } from '@/components/vectors';
+
+interface Props {
+  close: () => void;
+}
+export function QAModal({ close }: Props): JSX.Element {
+  return (
+    <div
+      role="dialog"
+      aria-label="질문과 답변 모달"
+      className="fixed inset-0 bg-white"
+    >
+      <header className="flex justify-start items-center bg-primary-dark shadow-md px-3 h-16">
+        <button type="button" className="rounded-full p-1" onClick={close}>
+          <ArrowBack className="fill-white" />
+          <span className="sr-only">뒤로 가기</span>
+        </button>
+      </header>
+    </div>
+  );
+}

--- a/src/components/panel/QAModal.tsx
+++ b/src/components/panel/QAModal.tsx
@@ -35,7 +35,7 @@ export function QAModal({
           <span className="sr-only">뒤로 가기</span>
         </button>
       </header>
-      <div className="flex flex-col gap-3 p-5 w-full border border-grey-light rounded-md">
+      <div className="flex flex-col gap-3 p-5 w-full border-y border-grey-light">
         <div className="flex items-center justify-between">
           <div className="flex justify-start items-center gap-1 overflow-hidden">
             <div role="img" aria-hidden>

--- a/src/components/panel/QuestionList.tsx
+++ b/src/components/panel/QuestionList.tsx
@@ -26,21 +26,29 @@ export function QuestionList({
   const likeSet = new Set(likeIds);
   const overlay = useOverlay();
 
-  function openModal(): void {
-    overlay.open(({ close }) => <QAModal close={close} />);
-  }
-  function handleQuestionItemClick(event: MouseEvent<HTMLDivElement>): void {
-    openModal();
+  function openModal(question: Question): void {
+    overlay.open(({ close }) => (
+      <QAModal
+        close={close}
+        question={question}
+        isActived={likeSet.has(question.id)}
+        onLikeButtonClick={onLikeButtonClick(question)}
+      />
+    ));
   }
 
-  function handleQuestionItemKeydown(
-    event: KeyboardEvent<HTMLDivElement>,
-  ): void {
-    if (event.key === 'Enter' || event.keyCode === 13) {
-      event.preventDefault();
-      openModal();
-    }
-  }
+  const handleQuestionItemClick =
+    (question: Question) => (event: MouseEvent<HTMLDivElement>) => {
+      openModal(question);
+    };
+
+  const handleQuestionItemKeydown =
+    (question: Question) => (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'Enter' || event.keyCode === 13) {
+        event.preventDefault();
+        openModal(question);
+      }
+    };
 
   return (
     <ul className="flex flex-col gap-3">
@@ -53,8 +61,8 @@ export function QuestionList({
                 role="button"
                 aria-label="질문과 답변 모달 열기"
                 className="flex flex-col gap-3 p-5 w-full border border-grey-light rounded-md"
-                onClick={handleQuestionItemClick}
-                onKeyDown={handleQuestionItemKeydown}
+                onClick={handleQuestionItemClick(question)}
+                onKeyDown={handleQuestionItemKeydown(question)}
                 tabIndex={0}
               >
                 <div className="flex items-center justify-between">

--- a/src/components/panel/QuestionList.tsx
+++ b/src/components/panel/QuestionList.tsx
@@ -6,7 +6,8 @@ import React from 'react';
 
 import { clsx } from 'clsx';
 
-import { ArrowBack, Like, Account } from '@/components/vectors';
+import { QAModal } from '@/components/panel/QAModal';
+import { Like, Account } from '@/components/vectors';
 import { useCurrentDate } from '@/hooks/useCurrentDate';
 import { useOverlay } from '@/hooks/useOverlay';
 import { formatDistance } from '@/lib/format-date';
@@ -26,20 +27,7 @@ export function QuestionList({
   const overlay = useOverlay();
 
   function openModal(): void {
-    overlay.open(({ close }) => (
-      <div
-        role="dialog"
-        aria-label="질문과 답변 모달"
-        className="fixed inset-0 bg-white"
-      >
-        <header className="flex justify-start items-center bg-primary-dark shadow-md px-3 h-16">
-          <button type="button" className="rounded-full p-1" onClick={close}>
-            <ArrowBack className="fill-white" />
-            <span className="sr-only">뒤로 가기</span>
-          </button>
-        </header>
-      </div>
-    ));
+    overlay.open(({ close }) => <QAModal close={close} />);
   }
   function handleQuestionItemClick(event: MouseEvent<HTMLDivElement>): void {
     openModal();

--- a/src/components/panel/__tests__/QAModal.test.tsx
+++ b/src/components/panel/__tests__/QAModal.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { QAModal } from '@/components/panel/QAModal';
+
+const handleClose = vi.fn();
+
+describe('QAModal', () => {
+  it('<- 아이콘을 누르면 close 함수가 호출된다', async () => {
+    render(<QAModal close={handleClose} />);
+
+    const goBackButton = screen.getByRole('button', { name: /뒤로 가기/ });
+    await userEvent.click(goBackButton);
+    expect(handleClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/panel/__tests__/QAModal.test.tsx
+++ b/src/components/panel/__tests__/QAModal.test.tsx
@@ -4,15 +4,39 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { QAModal } from '@/components/panel/QAModal';
+import { createMockQuestion } from '@/mocks/data/question';
 
 const handleClose = vi.fn();
+const question = { ...createMockQuestion(), content: '안녕하세요' };
+const isActived = true;
+const handleLikeButtonClick = vi.fn();
 
 describe('QAModal', () => {
   it('<- 아이콘을 누르면 close 함수가 호출된다', async () => {
-    render(<QAModal close={handleClose} />);
+    render(
+      <QAModal
+        close={handleClose}
+        question={question}
+        isActived={isActived}
+        onLikeButtonClick={handleLikeButtonClick}
+      />,
+    );
 
     const goBackButton = screen.getByRole('button', { name: /뒤로 가기/ });
     await userEvent.click(goBackButton);
     expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('질문을 보여준다', () => {
+    render(
+      <QAModal
+        close={handleClose}
+        question={question}
+        isActived={isActived}
+        onLikeButtonClick={handleLikeButtonClick}
+      />,
+    );
+
+    expect(screen.getByText(question.content)).toBeInTheDocument();
   });
 });

--- a/src/components/panel/__tests__/QuestionList.test.tsx
+++ b/src/components/panel/__tests__/QuestionList.test.tsx
@@ -5,11 +5,10 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { QuestionList } from '@/components/panel/QuestionList';
 import { OverlayProvider } from '@/contexts/OverlayContext';
 import { renderWithQueryClient } from '@/lib/test-utils';
 import { createMockQuestion } from '@/mocks/data/question';
-
-import { QuestionList } from '../QuestionList';
 
 const handleLikeButtonClick = vi.fn();
 const handleLikeButtonClickFn = vi.fn(() => handleLikeButtonClick);

--- a/src/pages/Panel.tsx
+++ b/src/pages/Panel.tsx
@@ -62,9 +62,9 @@ export function Panel(): JSX.Element {
     ));
   }
   return (
-    <main>
+    <main className="flex flex-col h-full overflow-auto">
       <PanelHeader panel={panel} />
-      <div className="container flex flex-col h-full max-w-2xl px-5 py-7">
+      <div className="flex-1 container flex flex-col max-w-2xl px-5 py-7">
         <InfiniteQuestionList panelId={panel.sid} />
       </div>
       <button
@@ -127,7 +127,7 @@ export function PanelErrorBoundary(): JSX.Element {
   }
 
   return (
-    <main className="h-full overflow-auto bg-gradient-to-r from-gray-50 to-slate-100">
+    <main className="h-full bg-gradient-to-r from-gray-50 to-slate-100">
       <header className="border-b border-grey-light">
         <div className="container flex justify-between items-center max-w-7xl px-5 h-16">
           <Link to="/" className="rounded-md font-bold">


### PR DESCRIPTION
## 🤷‍♂️ Description

- #424

<!-- 구현한 기능에 대해 작성해 주세요. -->

## 💥 질문 데이터가 캐시의 최신을 가리키지 않는다

오버레이를 열 당시의 데이터를 전달하므로 반응형이 아니다. (예: 좋아요 눌러도 반영 안 됨)
어차피 답변 목록 API에서 가져오는 질문 데이터로 대체할 것이므로 UI만 확인한다.

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

<img src="https://github.com/blacktokkies/toquiz-client/assets/57662010/ce9f424a-b3b6-4d80-a7f3-5aa8c5fae41d" width="500px" />

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

close #424