### PR TITLE
[회원 정보 페이지] 회원 탈퇴 #441

### DIFF
--- a/src/components/account/ResignModal.tsx
+++ b/src/components/account/ResignModal.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import { LabelInput } from '@/components/system/LabelInput';
 import { useResignMutation } from '@/hooks/queries/auth';
 import { useForm } from '@/hooks/useForm';
+import { clearAccessToken } from '@/lib/apiClient';
 import { isPassword } from '@/lib/validator';
+import { clearUserState } from '@/store/user-store';
 
 interface Props {
   close: () => void;
 }
 export function ResignModal({ close }: Props): JSX.Element {
+  const navigate = useNavigate();
   const resignMutation = useResignMutation();
   const { inputProps, errors, hasError, formProps } = useForm({
     inputConfigs: {
@@ -19,8 +24,17 @@ export function ResignModal({ close }: Props): JSX.Element {
       },
     },
     formConfig: {
-      onSubmit: (body) => {
-        resignMutation.mutate(body);
+      onSubmit: ({ password }) => {
+        resignMutation.mutate(
+          { password },
+          {
+            onSuccess: () => {
+              clearAccessToken();
+              clearUserState();
+              navigate('/');
+            },
+          },
+        );
       },
     },
   });

--- a/src/components/account/ResignModal.tsx
+++ b/src/components/account/ResignModal.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export function ResignModal(): JSX.Element {
+  return (
+    <div>
+      <h2>회원 탈퇴하기</h2>
+    </div>
+  );
+}

--- a/src/components/account/ResignModal.tsx
+++ b/src/components/account/ResignModal.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 
-export function ResignModal(): JSX.Element {
+interface Props {
+  close: () => void;
+}
+export function ResignModal({ close }: Props): JSX.Element {
   return (
     <div>
       <h2>회원 탈퇴하기</h2>
+      <button type="button" onClick={close}>
+        취소
+      </button>
     </div>
   );
 }

--- a/src/components/account/ResignModal.tsx
+++ b/src/components/account/ResignModal.tsx
@@ -9,7 +9,7 @@ interface Props {
   close: () => void;
 }
 export function ResignModal({ close }: Props): JSX.Element {
-  const { inputProps, errors } = useForm({
+  const { inputProps, errors, hasError } = useForm({
     inputConfigs: {
       password: {
         validate: (value) => isPassword(value),
@@ -29,6 +29,9 @@ export function ResignModal({ close }: Props): JSX.Element {
           {...inputProps.password}
           errorMessage={errors.password}
         />
+        <button type="submit" disabled={hasError}>
+          회원 탈퇴
+        </button>
       </form>
       <button type="button" onClick={close}>
         취소

--- a/src/components/account/ResignModal.tsx
+++ b/src/components/account/ResignModal.tsx
@@ -15,7 +15,7 @@ interface Props {
 export function ResignModal({ close }: Props): JSX.Element {
   const navigate = useNavigate();
   const resignMutation = useResignMutation();
-  const { inputProps, errors, hasError, formProps } = useForm({
+  const { inputProps, errors, hasError, formProps, setError } = useForm({
     inputConfigs: {
       password: {
         validate: (value) => isPassword(value),
@@ -32,6 +32,18 @@ export function ResignModal({ close }: Props): JSX.Element {
               clearAccessToken();
               clearUserState();
               navigate('/');
+            },
+            onError: (error) => {
+              if (error instanceof SyntaxError) return;
+
+              const { data } = error;
+              const { statusCode, code } = data;
+
+              if (statusCode === 400) {
+                if (code === 'NOT_MATCH_PASSWORD') {
+                  setError('password', '비밀번호가 일치하지 않습니다');
+                }
+              }
             },
           },
         );

--- a/src/components/account/ResignModal.tsx
+++ b/src/components/account/ResignModal.tsx
@@ -1,12 +1,35 @@
 import React from 'react';
 
+import { useForm } from '@/hooks/useForm';
+import { isPassword } from '@/lib/validator';
+
+import { LabelInput } from '../system/LabelInput';
+
 interface Props {
   close: () => void;
 }
 export function ResignModal({ close }: Props): JSX.Element {
+  const { inputProps, errors } = useForm({
+    inputConfigs: {
+      password: {
+        validate: (value) => isPassword(value),
+        errorMessage:
+          '8~20자 이하의 영문 대소문자, 숫자, 특수기호를 입력하세요',
+      },
+    },
+  });
+
   return (
     <div>
       <h2>회원 탈퇴하기</h2>
+      <form>
+        <LabelInput
+          id="password"
+          label="비밀번호"
+          {...inputProps.password}
+          errorMessage={errors.password}
+        />
+      </form>
       <button type="button" onClick={close}>
         취소
       </button>

--- a/src/components/account/ResignModal.tsx
+++ b/src/components/account/ResignModal.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 
+import { LabelInput } from '@/components/system/LabelInput';
+import { useResignMutation } from '@/hooks/queries/auth';
 import { useForm } from '@/hooks/useForm';
 import { isPassword } from '@/lib/validator';
-
-import { LabelInput } from '../system/LabelInput';
 
 interface Props {
   close: () => void;
 }
 export function ResignModal({ close }: Props): JSX.Element {
-  const { inputProps, errors, hasError } = useForm({
+  const resignMutation = useResignMutation();
+  const { inputProps, errors, hasError, formProps } = useForm({
     inputConfigs: {
       password: {
         validate: (value) => isPassword(value),
@@ -17,12 +18,17 @@ export function ResignModal({ close }: Props): JSX.Element {
           '8~20자 이하의 영문 대소문자, 숫자, 특수기호를 입력하세요',
       },
     },
+    formConfig: {
+      onSubmit: (body) => {
+        resignMutation.mutate(body);
+      },
+    },
   });
 
   return (
     <div>
       <h2>회원 탈퇴하기</h2>
-      <form>
+      <form {...formProps}>
         <LabelInput
           id="password"
           label="비밀번호"

--- a/src/components/account/ResignModal.tsx
+++ b/src/components/account/ResignModal.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { useNavigate } from 'react-router-dom';
 
+import { Button } from '@/components/system/Button';
 import { LabelInput } from '@/components/system/LabelInput';
 import { useResignMutation } from '@/hooks/queries/auth';
 import { useForm } from '@/hooks/useForm';
@@ -52,22 +53,36 @@ export function ResignModal({ close }: Props): JSX.Element {
   });
 
   return (
-    <div>
-      <h2>회원 탈퇴하기</h2>
-      <form {...formProps}>
+    <div className="flex flex-col p-7 gap-4">
+      <h2 className="font-medium text-lg">회원 탈퇴하기</h2>
+      <form
+        className="flex flex-col gap-3"
+        aria-label="회원 탈퇴 폼"
+        {...formProps}
+      >
+        <p>회원을 영구 탈퇴하려면 비밀번호를 입력하세요</p>
         <LabelInput
           id="password"
           label="비밀번호"
+          required={true}
+          type="password"
+          placeholder="비밀번호를 입력하세요"
           {...inputProps.password}
           errorMessage={errors.password}
         />
-        <button type="submit" disabled={hasError}>
-          회원 탈퇴
-        </button>
+        <div className="flex gap-3 justify-end items-center">
+          <Button variant="secondary" type="button" onClick={close}>
+            취소
+          </Button>
+          <Button
+            variant="danger"
+            type="submit"
+            disabled={hasError || resignMutation.isLoading}
+          >
+            회원 탈퇴
+          </Button>
+        </div>
       </form>
-      <button type="button" onClick={close}>
-        취소
-      </button>
     </div>
   );
 }

--- a/src/components/account/__tests__/ResignModal.test.tsx
+++ b/src/components/account/__tests__/ResignModal.test.tsx
@@ -1,9 +1,16 @@
+import type * as Vi from 'vitest';
+
 import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ResignModal } from '@/components/account/ResignModal';
+import { isPassword } from '@/lib/validator';
+
+vi.mock('@/lib/validator', () => ({
+  isPassword: vi.fn(() => true),
+}));
 
 const handleClose = vi.fn();
 describe('ResignModal', () => {
@@ -19,5 +26,19 @@ describe('ResignModal', () => {
     const closeButton = screen.getByRole('button', { name: /취소/ });
     await userEvent.click(closeButton);
     expect(handleClose).toHaveBeenCalled();
+  });
+
+  it('사용자가 유효하지 않은 비밀번호를 입력하면 에러 메시지를 보여준다', async () => {
+    (isPassword as Vi.Mock).mockImplementation(() => false);
+    render(<ResignModal close={handleClose} />);
+
+    const passwordInput = screen.getByLabelText('비밀번호');
+    await userEvent.type(passwordInput, '유효하지 않은 비밀번호');
+
+    expect(
+      screen.getByText(
+        '8~20자 이하의 영문 대소문자, 숫자, 특수기호를 입력하세요',
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/account/__tests__/ResignModal.test.tsx
+++ b/src/components/account/__tests__/ResignModal.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { ResignModal } from '@/components/account/ResignModal';
+
+describe('ResignModal', () => {
+  it('회원 탈퇴하기 헤딩을 보여준다', () => {
+    render(<ResignModal />);
+
+    expect(screen.getByRole('heading')).toHaveTextContent('회원 탈퇴하기');
+  });
+});

--- a/src/components/account/__tests__/ResignModal.test.tsx
+++ b/src/components/account/__tests__/ResignModal.test.tsx
@@ -2,7 +2,7 @@ import type * as Vi from 'vitest';
 
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ResignModal } from '@/components/account/ResignModal';
@@ -13,6 +13,12 @@ import { isPassword } from '@/lib/validator';
 vi.mock('@/lib/validator', () => ({
   isPassword: vi.fn(() => true),
 }));
+
+const navigateMockFn = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const router = (await importOriginal()) ?? {};
+  return { ...router, useNavigate: vi.fn(() => navigateMockFn) };
+});
 
 const handleClose = vi.fn();
 describe('ResignModal', () => {
@@ -65,5 +71,17 @@ describe('ResignModal', () => {
     });
     await userEvent.click(submitButton);
     expect(spyOnResign).toHaveBeenCalled();
+  });
+
+  it('[200] 성공 시 인덱스 페이지로 이동한다', async () => {
+    renderWithQueryClient(<ResignModal close={handleClose} />);
+    const submitButton = screen.getByRole<HTMLButtonElement>('button', {
+      name: '회원 탈퇴',
+    });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(navigateMockFn).toHaveBeenCalledWith('/');
+    });
   });
 });

--- a/src/components/account/__tests__/ResignModal.test.tsx
+++ b/src/components/account/__tests__/ResignModal.test.tsx
@@ -41,4 +41,17 @@ describe('ResignModal', () => {
       ),
     ).toBeInTheDocument();
   });
+
+  it('사용자가 유효하지 않은 비밀번호 입력하면 제출 버튼을 비활성화한다', async () => {
+    (isPassword as Vi.Mock).mockImplementation(() => false);
+    render(<ResignModal close={handleClose} />);
+
+    const passwordInput = screen.getByLabelText('비밀번호');
+    const submitButton = screen.getByRole<HTMLButtonElement>('button', {
+      name: '회원 탈퇴',
+    });
+    await userEvent.type(passwordInput, '유효하지 않은 비밀번호');
+
+    expect(submitButton.disabled).toBe(true);
+  });
 });

--- a/src/components/account/__tests__/ResignModal.test.tsx
+++ b/src/components/account/__tests__/ResignModal.test.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
 
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { ResignModal } from '@/components/account/ResignModal';
 
+const handleClose = vi.fn();
 describe('ResignModal', () => {
   it('회원 탈퇴하기 헤딩을 보여준다', () => {
-    render(<ResignModal />);
+    render(<ResignModal close={handleClose} />);
 
     expect(screen.getByRole('heading')).toHaveTextContent('회원 탈퇴하기');
+  });
+
+  it('취소 버튼을 누르면 close 함수를 호출한다', async () => {
+    render(<ResignModal close={handleClose} />);
+
+    const closeButton = screen.getByRole('button', { name: /취소/ });
+    await userEvent.click(closeButton);
+    expect(handleClose).toHaveBeenCalled();
   });
 });

--- a/src/hooks/queries/__tests__/auth.test.ts
+++ b/src/hooks/queries/__tests__/auth.test.ts
@@ -1,11 +1,11 @@
-import type { UpdateMyInfoBody } from '@/lib/api/auth';
+import type { UpdateMyInfoBody, ResignBody } from '@/lib/api/auth';
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 
 import * as authApis from '@/lib/api/auth';
 import { createQueryClientWrapper } from '@/lib/test-utils';
 
-import { useUpdateMyInfoMutation } from '../auth';
+import { useResignMutation, useUpdateMyInfoMutation } from '../auth';
 
 describe('auth queries', () => {
   describe('useUpdateMyInfoMutation', () => {
@@ -24,6 +24,26 @@ describe('auth queries', () => {
 
       await waitFor(() => {
         expect(spyOnUpdateMyInfo).toHaveBeenCalledWith(body);
+      });
+    });
+  });
+
+  describe('useResignMutation', () => {
+    it('mutate를 호출하면 resign을 호출한다', async () => {
+      const spyOnResign = vi.spyOn(authApis, 'resign');
+      const body: ResignBody = {
+        password: '비밀번호',
+      };
+      const { result } = renderHook(() => useResignMutation(), {
+        wrapper: createQueryClientWrapper(),
+      });
+
+      act(() => {
+        result.current.mutate(body);
+      });
+
+      await waitFor(() => {
+        expect(spyOnResign).toHaveBeenCalledWith(body);
       });
     });
   });

--- a/src/hooks/queries/auth.ts
+++ b/src/hooks/queries/auth.ts
@@ -9,13 +9,15 @@ import type {
   LogoutResponse,
   UpdateMyInfoResponse,
   UpdateMyInfoBody,
+  ResignResponse,
+  ResignBody,
 } from '@/lib/api/auth';
 import type { ApiError } from '@/lib/apiClient';
 import type { UseMutationResult } from '@tanstack/react-query';
 
 import { useMutation } from '@tanstack/react-query';
 
-import { login, logout, signUp, updateMyInfo } from '@/lib/api/auth';
+import { login, logout, resign, signUp, updateMyInfo } from '@/lib/api/auth';
 import { queryKey } from '@/lib/queryKey';
 
 export const useSignUpMutation = (): UseMutationResult<
@@ -71,5 +73,19 @@ export const useUpdateMyInfoMutation = (): UseMutationResult<
     ApiError | SyntaxError,
     UpdateMyInfoBody
   >(key, updateMyInfo);
+  return mutation;
+};
+
+export const useResignMutation = (): UseMutationResult<
+  ResignResponse,
+  ApiError | SyntaxError,
+  ResignBody
+> => {
+  const key = queryKey.auth.resign();
+  const mutation = useMutation<
+    ResignResponse,
+    ApiError | SyntaxError,
+    ResignBody
+  >(key, resign);
   return mutation;
 };

--- a/src/hooks/queries/auth.ts
+++ b/src/hooks/queries/auth.ts
@@ -11,6 +11,7 @@ import type {
   UpdateMyInfoBody,
   ResignResponse,
   ResignBody,
+  ResignError,
 } from '@/lib/api/auth';
 import type { ApiError } from '@/lib/apiClient';
 import type { UseMutationResult } from '@tanstack/react-query';
@@ -78,13 +79,13 @@ export const useUpdateMyInfoMutation = (): UseMutationResult<
 
 export const useResignMutation = (): UseMutationResult<
   ResignResponse,
-  ApiError | SyntaxError,
+  ApiError<ResignError> | SyntaxError,
   ResignBody
 > => {
   const key = queryKey.auth.resign();
   const mutation = useMutation<
     ResignResponse,
-    ApiError | SyntaxError,
+    ApiError<ResignError> | SyntaxError,
     ResignBody
   >(key, resign);
   return mutation;

--- a/src/lib/api/__tests__/auth.test.ts
+++ b/src/lib/api/__tests__/auth.test.ts
@@ -2,7 +2,7 @@ import type { UpdateMyInfoBody } from '@/lib/api/auth';
 
 import { apiUrl } from '@/lib/api/apiUrl';
 
-import { updateMyInfo } from '../auth';
+import { resign, updateMyInfo } from '../auth';
 
 describe('auth api', () => {
   it(`updateMyInfo를 호출하면 내 정보 수정 API(${apiUrl.auth.update()})로 요청한다`, async () => {
@@ -11,5 +11,13 @@ describe('auth api', () => {
     };
     const { result } = await updateMyInfo(body);
     expect(result.nickname).toBe(body.nickname);
+  });
+
+  it(`resign을 호출하면 회원 탈퇴 API(${apiUrl.auth.resign()})로 요청한다`, async () => {
+    const body = {
+      password: '비밀번호',
+    };
+    const { message } = await resign(body);
+    expect(message).toBe('회원탈퇴에 성공하였습니다.');
   });
 });

--- a/src/lib/api/apiUrl.ts
+++ b/src/lib/api/apiUrl.ts
@@ -7,6 +7,7 @@ const auth = {
   refresh: () => `/api/auth/refresh`,
   me: () => `/api/members/me`,
   update: () => `/api/members/me`,
+  resign: () => `/api/auth/resign`,
 } as const;
 
 const panel = {

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -51,6 +51,13 @@ export const updateMyInfo = async (
     body,
   );
 
+export interface ResignBody {
+  password: Member['password'];
+}
+export type ResignResponse = SuccessResponse;
+export const resign = async (body: ResignBody): Promise<ResignResponse> =>
+  apiClient.post<ResignResponse, ResignBody>(apiUrl.auth.resign(), body);
+
 /* ================================ [ 회원가입 API ] ====================================== */
 export interface SignUpBody {
   email: Member['email'];

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -55,6 +55,11 @@ export interface ResignBody {
   password: Member['password'];
 }
 export type ResignResponse = SuccessResponse;
+export type ResignError = NotMatchPasswordResignError;
+export type NotMatchPasswordResignError = ErrorResponse & {
+  code: 'NOT_MATCH_PASSWORD';
+  statusCode: 400;
+};
 export const resign = async (body: ResignBody): Promise<ResignResponse> =>
   apiClient.post<ResignResponse, ResignBody>(apiUrl.auth.resign(), body);
 

--- a/src/lib/queryKey.ts
+++ b/src/lib/queryKey.ts
@@ -6,6 +6,7 @@ const authQueryKey = {
   login: () => ['login'] as const,
   logout: () => ['logout'] as const,
   update: () => ['updateMyInfo'] as const,
+  resign: () => ['resign'] as const,
 } as const;
 
 const panelQueryKey = {

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -9,6 +9,8 @@ import type {
   GetMyInfoResponse,
   UpdateMyInfoBody,
   UpdateMyInfoResponse,
+  ResignBody,
+  ResignResponse,
 } from '@/lib/api/auth';
 import type { ErrorResponse } from '@/lib/api/types';
 
@@ -153,3 +155,15 @@ export const updateMyInfo = rest.patch<
     }),
   );
 });
+
+export const resign = rest.post<ResignBody, never, ResignResponse>(
+  apiUrl.auth.resign(),
+  async (req, res, ctx) =>
+    res(
+      ctx.status(200),
+      ctx.json({
+        statusCode: 200,
+        message: '회원탈퇴에 성공하였습니다.',
+      }),
+    ),
+);

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -161,6 +161,7 @@ export const resign = rest.post<ResignBody, never, ResignResponse>(
   async (req, res, ctx) =>
     res(
       ctx.status(200),
+      ctx.cookie('refreshToken', '', { expires: new Date() }),
       ctx.json({
         statusCode: 200,
         message: '회원탈퇴에 성공하였습니다.',

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -111,9 +111,14 @@ export function Account(): JSX.Element {
             </div>
           </form>
         </section>
-        <section className="flex flex-col gap-6 py-6">
+        <section className="flex flex-col justify-start items-start gap-6 py-6">
           <h2 className="font-medium text-xl">회원 탈퇴</h2>
-          <button
+          <p>
+            회원 탈퇴시 작성했던 패널은 자동으로 삭제되지 않습니다. 정말{' '}
+            <b>회원을 영구 탈퇴</b>하시겠습니까?
+          </p>
+          <Button
+            variant="danger"
             type="button"
             onClick={() => {
               overlay.open(({ close }) => (
@@ -124,7 +129,7 @@ export function Account(): JSX.Element {
             }}
           >
             회원 영구 탈퇴
-          </button>
+          </Button>
         </section>
       </div>
     </div>

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -7,8 +7,10 @@ import { redirect } from 'react-router-dom';
 
 import { Button } from '@/components/system/Button';
 import { LabelInput } from '@/components/system/LabelInput';
+import { ModalController } from '@/components/system/ModalController';
 import { useUpdateMyInfoMutation } from '@/hooks/queries/auth';
 import { useForm } from '@/hooks/useForm';
+import { useOverlay } from '@/hooks/useOverlay';
 import { isUserLoggedIn } from '@/lib/routeGuard';
 import { isNickname, isPassword } from '@/lib/validator';
 
@@ -59,6 +61,9 @@ export function Account(): JSX.Element {
       },
     },
   });
+
+  const overlay = useOverlay();
+
   return (
     <div className="flex-1 container flex flex-col max-w-5xl px-5 pt-7 pb-16">
       <h1 className="font text-2xl font-medium tracking-tighter md:text-5xl">
@@ -108,6 +113,18 @@ export function Account(): JSX.Element {
         </section>
         <section className="flex flex-col gap-6 py-6">
           <h2 className="font-medium text-xl">회원 탈퇴</h2>
+          <button
+            type="button"
+            onClick={() => {
+              overlay.open(({ close }) => (
+                <ModalController aria-label="회원 탈퇴 모달" close={close}>
+                  회원 탈퇴
+                </ModalController>
+              ));
+            }}
+          >
+            회원 영구 탈퇴
+          </button>
         </section>
       </div>
     </div>

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -5,6 +5,7 @@ import React, { useRef } from 'react';
 
 import { redirect } from 'react-router-dom';
 
+import { ResignModal } from '@/components/account/ResignModal';
 import { Button } from '@/components/system/Button';
 import { LabelInput } from '@/components/system/LabelInput';
 import { ModalController } from '@/components/system/ModalController';
@@ -123,7 +124,7 @@ export function Account(): JSX.Element {
             onClick={() => {
               overlay.open(({ close }) => (
                 <ModalController aria-label="회원 탈퇴 모달" close={close}>
-                  회원 탈퇴
+                  <ResignModal />
                 </ModalController>
               ));
             }}

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -106,6 +106,9 @@ export function Account(): JSX.Element {
             </div>
           </form>
         </section>
+        <section className="flex flex-col gap-6 py-6">
+          <h2 className="font-medium text-xl">회원 탈퇴</h2>
+        </section>
       </div>
     </div>
   );

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -124,7 +124,7 @@ export function Account(): JSX.Element {
             onClick={() => {
               overlay.open(({ close }) => (
                 <ModalController aria-label="회원 탈퇴 모달" close={close}>
-                  <ResignModal />
+                  <ResignModal close={close} />
                 </ModalController>
               ));
             }}

--- a/src/pages/__tests__/Account.test.tsx
+++ b/src/pages/__tests__/Account.test.tsx
@@ -15,6 +15,12 @@ vi.mock('@/lib/validator', () => ({
   isNickname: vi.fn(() => true),
   isPassword: vi.fn(() => true),
 }));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const router = (await importOriginal()) ?? {};
+  return { ...router, useNavigate: vi.fn() };
+});
+
 describe('내 계정 관리 페이지', () => {
   it('내 계정 관리 헤딩을 보여준다.', () => {
     renderWithQueryClient(

--- a/src/pages/__tests__/Account.test.tsx
+++ b/src/pages/__tests__/Account.test.tsx
@@ -32,8 +32,9 @@ describe('내 계정 관리 페이지', () => {
       expect(
         screen.getByRole<HTMLHeadingElement>('heading', {
           level: 2,
+          name: '프로필 수정',
         }),
-      ).toHaveTextContent('프로필 수정');
+      ).toBeInTheDocument();
     });
 
     it('프로필 수정 폼을 보여준다', () => {
@@ -136,6 +137,19 @@ describe('내 계정 관리 페이지', () => {
       await userEvent.click(submitButton);
       expect(spyOnUpdateMyInfo).not.toHaveBeenCalled();
       expect(screen.getByText(/변경할 내용을 입력해주세요/));
+    });
+  });
+
+  describe('회원 탈퇴', () => {
+    it('회원 탈퇴 헤딩을 보여준다', () => {
+      renderWithQueryClient(<Account />);
+
+      expect(
+        screen.getByRole<HTMLHeadingElement>('heading', {
+          level: 2,
+          name: '회원 탈퇴',
+        }),
+      );
     });
   });
 });

--- a/src/pages/__tests__/Account.test.tsx
+++ b/src/pages/__tests__/Account.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { OverlayProvider } from '@/contexts/OverlayContext';
 import * as authApis from '@/lib/api/auth';
 import { renderWithQueryClient } from '@/lib/test-utils';
 import { isNickname, isPassword } from '@/lib/validator';
@@ -16,7 +17,11 @@ vi.mock('@/lib/validator', () => ({
 }));
 describe('내 계정 관리 페이지', () => {
   it('내 계정 관리 헤딩을 보여준다.', () => {
-    renderWithQueryClient(<Account />);
+    renderWithQueryClient(
+      <OverlayProvider>
+        <Account />
+      </OverlayProvider>,
+    );
 
     expect(
       screen.getByRole('heading', {
@@ -27,7 +32,11 @@ describe('내 계정 관리 페이지', () => {
 
   describe('프로필 수정', () => {
     it('프로필 수정 헤딩을 보여준다', () => {
-      renderWithQueryClient(<Account />);
+      renderWithQueryClient(
+        <OverlayProvider>
+          <Account />
+        </OverlayProvider>,
+      );
 
       expect(
         screen.getByRole<HTMLHeadingElement>('heading', {
@@ -38,7 +47,11 @@ describe('내 계정 관리 페이지', () => {
     });
 
     it('프로필 수정 폼을 보여준다', () => {
-      renderWithQueryClient(<Account />);
+      renderWithQueryClient(
+        <OverlayProvider>
+          <Account />
+        </OverlayProvider>,
+      );
 
       const form = screen.getByRole('form', {
         name: /프로필 수정 폼/,
@@ -49,7 +62,11 @@ describe('내 계정 관리 페이지', () => {
 
     it('사용자가 유효하지 않은 닉네임을 입력하면 에러 메시지를 보여준다', () => {
       (isNickname as Vi.Mock).mockImplementation(() => false);
-      renderWithQueryClient(<Account />);
+      renderWithQueryClient(
+        <OverlayProvider>
+          <Account />
+        </OverlayProvider>,
+      );
 
       const nicknameInput = screen.getByLabelText(/닉네임/);
       fireEvent.change(nicknameInput, {
@@ -63,7 +80,11 @@ describe('내 계정 관리 페이지', () => {
 
     it('사용자가 유효하지 않은 비밀번호를 입력하면 에러 메시지를 보여준다', () => {
       (isPassword as Vi.Mock).mockImplementation(() => false);
-      renderWithQueryClient(<Account />);
+      renderWithQueryClient(
+        <OverlayProvider>
+          <Account />
+        </OverlayProvider>,
+      );
 
       const passwordInput = screen.getByLabelText('비밀번호');
       fireEvent.change(passwordInput, {
@@ -78,7 +99,11 @@ describe('내 계정 관리 페이지', () => {
     });
 
     it('사용자가 비밀번호 확인 인풋에 비밀번호 인풋과 동일하지 않은 값 입력하면 에러 메시지를 보여준다', () => {
-      renderWithQueryClient(<Account />);
+      renderWithQueryClient(
+        <OverlayProvider>
+          <Account />
+        </OverlayProvider>,
+      );
 
       const passwordInput = screen.getByLabelText('비밀번호');
       const confirmPasswordInput = screen.getByLabelText(/비밀번호 확인/);
@@ -96,7 +121,11 @@ describe('내 계정 관리 페이지', () => {
 
     it('사용자가 유효하지 않은 값을 입력하면 제출 버튼을 비활성화한다', () => {
       (isNickname as Vi.Mock).mockImplementation(() => false);
-      renderWithQueryClient(<Account />);
+      renderWithQueryClient(
+        <OverlayProvider>
+          <Account />
+        </OverlayProvider>,
+      );
 
       const nicknameInput = screen.getByLabelText(/닉네임/);
       fireEvent.change(nicknameInput, {
@@ -111,7 +140,11 @@ describe('내 계정 관리 페이지', () => {
 
     it('사용자가 값을 제출하면 내 정보 수정 API를 호출한다', async () => {
       const spyOnUpdateMyInfo = vi.spyOn(authApis, 'updateMyInfo');
-      renderWithQueryClient(<Account />);
+      renderWithQueryClient(
+        <OverlayProvider>
+          <Account />
+        </OverlayProvider>,
+      );
 
       const nicknameInput = screen.getByLabelText(/닉네임/);
       fireEvent.change(nicknameInput, {
@@ -129,7 +162,11 @@ describe('내 계정 관리 페이지', () => {
 
     it('사용자가 닉네임과 비밀번호를 모두 빈 값으로 제출하면 내 정보 수정 API를 호출하지 않고 안내 문구를 보여준다', async () => {
       const spyOnUpdateMyInfo = vi.spyOn(authApis, 'updateMyInfo');
-      renderWithQueryClient(<Account />);
+      renderWithQueryClient(
+        <OverlayProvider>
+          <Account />
+        </OverlayProvider>,
+      );
 
       const submitButton = screen.getByRole<HTMLButtonElement>('button', {
         name: /변경 내용 저장/,
@@ -142,7 +179,11 @@ describe('내 계정 관리 페이지', () => {
 
   describe('회원 탈퇴', () => {
     it('회원 탈퇴 헤딩을 보여준다', () => {
-      renderWithQueryClient(<Account />);
+      renderWithQueryClient(
+        <OverlayProvider>
+          <Account />
+        </OverlayProvider>,
+      );
 
       expect(
         screen.getByRole<HTMLHeadingElement>('heading', {
@@ -150,6 +191,21 @@ describe('내 계정 관리 페이지', () => {
           name: '회원 탈퇴',
         }),
       );
+    });
+
+    it('회원 영구 탈퇴 버튼을 누르면 회원 탈퇴하기 모달을 연다', async () => {
+      renderWithQueryClient(
+        <OverlayProvider>
+          <Account />
+        </OverlayProvider>,
+      );
+
+      const openResignModalButton = screen.getByRole('button', {
+        name: '회원 영구 탈퇴',
+      });
+      await userEvent.click(openResignModalButton);
+
+      expect(screen.getByRole('dialog', { name: /회원 탈퇴/ }));
     });
   });
 });


### PR DESCRIPTION
## 🤷‍♂️ Description

- #441

<!-- 구현한 기능에 대해 작성해 주세요. -->

## 💥 회원 탈퇴 실패 [401] INVALID_ACCESS_TOKEN은 라우트 에러 바운더리 단계에서 처리할 것이므로 현재 지역적으로 에러 핸들링 하지 않음

- 에러 바운더리에서 처리하도록 로직 세울 것임

## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

### 회원 탈퇴 성공 [200]
<img src="https://github.com/blacktokkies/toquiz-client/assets/57662010/a5878d14-741c-4687-af06-3415bbc12d48" width="500px" />

<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

### 회원 탈퇴 실패 [400] NOT_MATCH_PASSWORD

<img src="https://github.com/blacktokkies/toquiz-client/assets/57662010/fbb40e9e-ee68-4ab9-beb8-dc42dfe37ce4" width="500px" />


close #441