### PR TITLE
[패널 페이지] 전체 컴포넌트가 렌더링되지 않도록 현재 시각 나타내는 상태를 말단으로 내린다

### DIFF
--- a/src/components/panel/AnswerList.tsx
+++ b/src/components/panel/AnswerList.tsx
@@ -2,15 +2,15 @@ import type { Answer } from '@/lib/api/answer';
 
 import React from 'react';
 
+import { TimeDiff } from '@/components/system/TimeDiff';
 import { Account } from '@/components/vectors';
-import { formatDistance } from '@/lib/format-date';
 
 interface Props {
   nickname: string;
   answers: Answer[];
-  now: Date;
 }
-export function AnswerList({ nickname, answers, now }: Props): JSX.Element {
+export function AnswerList({ nickname, answers }: Props): JSX.Element {
+  const now = new Date();
   return (
     <ul>
       {answers.map((answer) => (
@@ -24,9 +24,11 @@ export function AnswerList({ nickname, answers, now }: Props): JSX.Element {
                 <Account className="fill-grey-darkest" />
               </div>
               <div className="font-bold whitespace-nowrap">{nickname}</div>
-              <div className="text-grey-dark">
-                {formatDistance(now, new Date(answer.createdAt))}
-              </div>
+              <TimeDiff
+                className="text-grey-dark"
+                base={now}
+                target={new Date(answer.createdAt)}
+              />
             </div>
           </div>
           <div className="whitespace-pre-wrap">{answer.content}</div>

--- a/src/components/panel/QAModal.tsx
+++ b/src/components/panel/QAModal.tsx
@@ -20,7 +20,6 @@ import {
   useCreateAnswerMutation,
 } from '@/hooks/queries/answer';
 import { useUserStore } from '@/hooks/stores/useUserStore';
-import { useCurrentDate } from '@/hooks/useCurrentDate';
 import { useOutsideClick } from '@/hooks/useOutsideClick';
 import { queryKey } from '@/lib/queryKey';
 
@@ -45,7 +44,6 @@ export function QAModal({
   // [NOTE] 질문과 답변 모달은 패널 페이지에서만 사용되므로
   // 패널 페이지 로더가 반환하는 데이터가 null이 아님이 보장된다
   const panelLoaderData = useRouteLoaderData('panel') as Panel;
-  const now = useCurrentDate();
   const answersQuery = useAnswersQuery(questionId);
 
   const [expanded, setExpanded] = useState(false);
@@ -237,7 +235,7 @@ export function QAModal({
         </div>
       )}
       <div className="flex-1">
-        <AnswerList answers={answers} nickname={author.nickname} now={now} />
+        <AnswerList answers={answers} nickname={author.nickname} />
       </div>
     </div>
   );

--- a/src/components/panel/QuestionItem.tsx
+++ b/src/components/panel/QuestionItem.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 
 import { clsx } from 'clsx';
 
+import { TimeDiff } from '@/components/system/TimeDiff';
 import { Like, Account } from '@/components/vectors';
-import { formatDistance } from '@/lib/format-date';
 
 interface Props {
   question: Question;
@@ -29,9 +29,11 @@ export function QuestionItem({
             <Account className="fill-grey-darkest" />
           </div>
           <div className="font-bold whitespace-nowrap">익명</div>
-          <div className="text-grey-dark">
-            {formatDistance(now, new Date(question.createdAt))}
-          </div>
+          <TimeDiff
+            className="text-grey-dark"
+            base={now}
+            target={new Date(question.createdAt)}
+          />
           {question.answerNum ? (
             <span className="ml-1 px-3 rounded-2xl bg-primary text-white text-sm">
               답변 {question.answerNum}개

--- a/src/components/panel/QuestionList.tsx
+++ b/src/components/panel/QuestionList.tsx
@@ -21,7 +21,6 @@ import {
   useActiveInfoDetailQuery,
 } from '@/hooks/queries/active-info';
 import { useLikeQuestionMutation } from '@/hooks/queries/question';
-import { useCurrentDate } from '@/hooks/useCurrentDate';
 import { useOverlay } from '@/hooks/useOverlay';
 import { ApiError } from '@/lib/apiClient';
 import { queryKey } from '@/lib/queryKey';
@@ -154,7 +153,7 @@ export function QuestionList({
       }
     };
 
-  const now = useCurrentDate();
+  const now = new Date();
 
   return (
     <ul className="flex flex-col gap-3">

--- a/src/components/panel/__tests__/AnswerList.test.tsx
+++ b/src/components/panel/__tests__/AnswerList.test.tsx
@@ -14,9 +14,7 @@ describe('AnswerList', () => {
       { ...createMockAnswer(), content: '안녕하세요' },
       { ...createMockAnswer(), content: '반가워요' },
     ];
-    render(
-      <AnswerList nickname={'닉네임'} answers={answers} now={new Date()} />,
-    );
+    render(<AnswerList nickname={'닉네임'} answers={answers} />);
 
     expect(screen.getByText(/안녕하세요/)).toBeInTheDocument();
     expect(screen.getByText(/반가워요/)).toBeInTheDocument();

--- a/src/components/system/TimeDiff.tsx
+++ b/src/components/system/TimeDiff.tsx
@@ -1,0 +1,16 @@
+import type { HTMLAttributes } from 'react';
+
+import React from 'react';
+
+import { useCurrentDate } from '@/hooks/useCurrentDate';
+import { formatDistance } from '@/lib/format-date';
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  base: Date;
+  target: Date;
+}
+
+export function TimeDiff({ base, target, ...rest }: Props): JSX.Element {
+  const now = useCurrentDate({ start: base });
+  return <div {...rest}>{formatDistance(now, target)}</div>;
+}

--- a/src/hooks/useCurrentDate.tsx
+++ b/src/hooks/useCurrentDate.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-export function useCurrentDate(delay = 1000): Date {
-  const [currentDate, setCurrentDate] = useState(new Date());
+export function useCurrentDate({ delay = 1000, start = new Date() }): Date {
+  const [currentDate, setCurrentDate] = useState(start);
 
   useEffect(() => {
     const interval = setInterval(() => {


### PR DESCRIPTION
## 🤷‍♂️ Description

- #394 

<!-- 구현한 기능에 대해 작성해 주세요. -->


## 📷 Screenshots

<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->

## 💥 개선 전

<img src="https://github.com/blacktokkies/toquiz-client/assets/57662010/a9922b93-0022-4039-a155-4fb1811a7dcf" width="500px" />

## 🤸‍♂️개선 후

<img src="https://github.com/blacktokkies/toquiz-client/assets/57662010/5b925277-159d-4733-a14a-177e8b477536" width="500px" />


<!--마지막으로 이슈 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->

close #394